### PR TITLE
fix: use proper antialiased keyword

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -64,7 +64,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang='en'>
-      <body className={`${inter.className} antialased`}>{children}</body>
+      <body className={`${inter.className} antialiased`}>{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
I was just looking through your code since I was learning Next.js, and noticed that the `antialiased` keyword was spelled incorrectly in the root `layout.tsx` file. Hope this helps :)